### PR TITLE
Fix Lint on Type Alias

### DIFF
--- a/1. Beginner/1. Get Up And Running FAST!/data_types/src/main.rs
+++ b/1. Beginner/1. Get Up And Running FAST!/data_types/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
     let unit = ();
 
     // Type aliasing
-    type age = u8;
+    type Age = u8;
 
-    let a1: age = 57;
+    let a1: Age = 57;
 }


### PR DESCRIPTION
Type `age` should have a camel case name such as `Age`