### PR TITLE
Removed use of tempfile persist.

### DIFF
--- a/4. Projects/1. CLI/Problem/Stage 1/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 1/Step 2/src/db.rs
@@ -92,6 +92,7 @@ mod tests {
             let read_result = db.read_db().unwrap();
 
             assert_eq!(write_result.is_ok(), true);
+            // TODO: fix this error by deriving the appropriate traits for DBState
             assert_eq!(read_result, state);
         }
     }

--- a/4. Projects/1. CLI/Problem/Stage 1/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 1/Step 2/src/db.rs
@@ -27,7 +27,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Problem/Stage 1/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 1/Step 2/src/db.rs
@@ -45,16 +45,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -66,16 +60,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -87,12 +75,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -108,10 +92,7 @@ mod tests {
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
 
-            remove_file(file_path).unwrap();
-
             assert_eq!(write_result.is_ok(), true);
-            // TODO: fix this error by deriving the appropriate traits for DBState
             assert_eq!(read_result, state);
         }
     }

--- a/4. Projects/1. CLI/Problem/Stage 1/Step 3/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 1/Step 3/src/db.rs
@@ -330,7 +330,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Problem/Stage 1/Step 3/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 1/Step 3/src/db.rs
@@ -348,16 +348,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -369,16 +363,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -390,12 +378,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -410,8 +394,6 @@ mod tests {
 
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 1/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 1/src/db.rs
@@ -376,7 +376,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 1/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 1/src/db.rs
@@ -394,16 +394,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -415,16 +409,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -436,12 +424,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -456,8 +440,6 @@ mod tests {
 
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/db.rs
@@ -376,7 +376,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/db.rs
@@ -442,5 +442,6 @@ mod tests {
 
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);
-        }    }
+        }
+    }
 }

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/db.rs
@@ -394,16 +394,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -415,16 +409,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -436,12 +424,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -457,10 +441,7 @@ mod tests {
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
 
-            remove_file(file_path).unwrap();
-
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);
-        }
-    }
+        }    }
 }

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/io_utils.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/io_utils.rs
@@ -7,5 +7,7 @@ pub fn get_user_input() -> String {
         .read_line(&mut user_input)
         .unwrap();
 
+
     user_input
+
 }

--- a/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/io_utils.rs
+++ b/4. Projects/1. CLI/Problem/Stage 2/Step 2/src/io_utils.rs
@@ -7,7 +7,5 @@ pub fn get_user_input() -> String {
         .read_line(&mut user_input)
         .unwrap();
 
-
     user_input
-
 }

--- a/4. Projects/1. CLI/Problem/Stage 3/Step 1/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 3/Step 1/src/db.rs
@@ -376,7 +376,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Problem/Stage 3/Step 1/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 3/Step 1/src/db.rs
@@ -394,16 +394,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -415,16 +409,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -436,12 +424,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -456,8 +440,6 @@ mod tests {
 
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);

--- a/4. Projects/1. CLI/Problem/Stage 3/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 3/Step 2/src/db.rs
@@ -376,7 +376,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Problem/Stage 3/Step 2/src/db.rs
+++ b/4. Projects/1. CLI/Problem/Stage 3/Step 2/src/db.rs
@@ -394,16 +394,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -415,16 +409,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -436,12 +424,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -456,8 +440,6 @@ mod tests {
 
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);

--- a/4. Projects/1. CLI/Solution/src/db.rs
+++ b/4. Projects/1. CLI/Solution/src/db.rs
@@ -376,7 +376,6 @@ mod tests {
 
     mod database {
         use std::collections::HashMap;
-        use std::fs::{remove_file};
         use std::io::Write;
 
         use super::*;

--- a/4. Projects/1. CLI/Solution/src/db.rs
+++ b/4. Projects/1. CLI/Solution/src/db.rs
@@ -394,16 +394,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0 epics: {} stories {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_fail_with_invalid_json.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_err(), true);
         }
@@ -415,16 +409,10 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/read_db_should_parse_json_file.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let result = db.read_db();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(result.is_ok(), true);
         }
@@ -436,12 +424,8 @@ mod tests {
             let file_contents = r#"{ "last_item_id": 0, "epics": {}, "stories": {} }"#;
             write!(tmpfile, "{}", file_contents).unwrap();
 
-            let file_path = "./data/write_db_should_work.json".to_owned();
-
-            let path = tmpfile.into_temp_path();
-            path.persist(&file_path).unwrap();
-
-            let db = JSONFileDatabase { file_path: file_path.clone() };
+            let db = JSONFileDatabase { file_path: tmpfile.path().to_str()
+                .expect("failed to convert tmpfile path to str").to_string() };
 
             let story = Story { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open };
             let epic = Epic { name: "epic 1".to_owned(), description: "epic 1".to_owned(), status: Status::Open, stories: vec![2] };
@@ -456,8 +440,6 @@ mod tests {
 
             let write_result = db.write_db(&state);
             let read_result = db.read_db().unwrap();
-
-            remove_file(file_path).unwrap();
 
             assert_eq!(write_result.is_ok(), true);
             assert_eq!(read_result, state);


### PR DESCRIPTION
For users who have their project on a different storage device to their temp directory it causes a panic.

The code creates a temporary file, then persists it to the data directory only to remove it within the test. This seems superfluous.

The current setup just uses the tempfile where it stands and relies on the destructors in tempfile to remove files when they fall out of scope. If there is a better way to convert the `tmpfile.path` to a `String`, I would appreciate the input.

I have tested the Solution tests on OSX, Windows and Linux. All passed.

Example error:
```
--- db::tests::database::read_db_should_fail_with_invalid_json stdout ----
thread 'db::tests::database::read_db_should_fail_with_invalid_json' panicked at 'called `Result::unwrap()` on an `Err` value: PathPersistError { error: Os { code: 17, kind: CrossesDevices, message: "The system cannot move the file to a different disk drive." }, path: "C:\\Users\\...\\AppData\\Local\\Temp\\.tmpvnwYSi" }', src\db.rs:56:38
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```