### PR TITLE
Add http file for IntelliJ IDEA

### DIFF
--- a/4. Projects/2. API/.http/http-client.env.json
+++ b/4. Projects/2. API/.http/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "server": "http://localhost:8000"
+  }
+}

--- a/4. Projects/2. API/.http/testing.http
+++ b/4. Projects/2. API/.http/testing.http
@@ -1,0 +1,46 @@
+### Create question
+POST {{server}}/question
+Content-Type: application/json
+
+{
+  "title": "Title {{$random.alphabetic(3)}}",
+  "description": "Description {{$random.alphabetic(5)}}"
+}
+> {% client.global.set("last_inserted_question_uuid", response.body.question_uuid); %}
+
+### Get questions
+GET {{server}}/questions
+
+### Delete question
+DELETE {{server}}/question
+Content-Type: application/json
+
+{
+  "question_uuid": "{{last_inserted_question_uuid}}"
+}
+
+### Create answer
+POST {{server}}/answer
+Content-Type: application/json
+
+{
+  "question_uuid": "{{last_inserted_question_uuid}}",
+  "content": "Content {{$random.alphabetic(10)}}"
+}
+> {% client.global.set("last_inserted_answer_uuid", response.body.answer_uuid); %}
+
+### Get answers
+GET {{server}}/answers
+Content-Type: application/json
+
+{
+  "question_uuid": "{{last_inserted_question_uuid}}"
+}
+
+### Delete answer
+DELETE {{server}}/answer
+Content-Type: application/json
+
+{
+  "answer_uuid": "{{last_inserted_answer_uuid}}"
+}

--- a/4. Projects/2. API/Problem/Stage 1/README.md
+++ b/4. Projects/2. API/Problem/Stage 1/README.md
@@ -246,7 +246,9 @@ Tip: Use [cargo watch](https://github.com/watchexec/cargo-watch) instead of `car
 
 Now that your server it running, test it out by calling the endpoints!
 
-You can call the endpoints using [cURL](https://en.wikipedia.org/wiki/CURL):
+You can call the endpoints using
+- [cURL](https://en.wikipedia.org/wiki/CURL) or
+- [HTTP Client](https://www.jetbrains.com/help/phpstorm/2023.2/http-client-in-product-code-editor.html) integrated in IntelliJ IDEA ([http file](https://github.com/letsgetrusty/bootcamp/blob/master/4.%20Projects/2.%20API/.http/testing.http))
 
 Create question
 


### PR DESCRIPTION
This integrates the [test requests](https://github.com/letsgetrusty/bootcamp/tree/880a02bb1eb9e835e3f3d7d78c609e6cd3afc1c6/4.%20Projects/2.%20API/Problem/Stage%201#testing) of the [API project](https://github.com/letsgetrusty/bootcamp/tree/880a02bb1eb9e835e3f3d7d78c609e6cd3afc1c6/4.%20Projects/2.%20API/Problem) into the [HTTP Client](https://www.jetbrains.com/help/phpstorm/2023.2/http-client-in-product-code-editor.html) of IntelliJ IDEA, which is a comfortable way of doing API calls without using `curl` manually.

JetBrain's users will be happy about it.
