### PR TITLE
fix: Typo in Projects/CLI/Stage2 readme - iterools > itertools

### DIFF
--- a/4. Projects/1. CLI/Problem/Stage 2/README.md
+++ b/4. Projects/1. CLI/Problem/Stage 2/README.md
@@ -82,7 +82,7 @@ __NOTE 2:__ `page_helpers.rs` contains a function called `get_column_string()` w
 
 __NOTE 3:__ Use `get_column_string()` inside the `draw_page()` methods.
 
-__NOTE 4:__ The `iterools` dependency has also been added. This allows you to sort an iterator by calling `sorted()` on it.
+__NOTE 4:__ The `itertools` dependency has also been added. This allows you to sort an iterator by calling `sorted()` on it.
 
 ### Step 2
 


### PR DESCRIPTION
found a typo in CLI Project's readme.
- crate name misspelled `iterools` -> `itertools`