### PR TITLE
fix: prod.yaml spacing, Bump: rust version for deps

### DIFF
--- a/4. Projects/3. Microservices/Problem/Stage 2/Step 2/.github/workflows/prod.yml
+++ b/4. Projects/3. Microservices/Problem/Stage 2/Step 2/.github/workflows/prod.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-   pull_request:
+  pull_request:
     branches:
       - master
 

--- a/4. Projects/3. Microservices/Problem/Stage 2/Step 2/Dockerfile-auth
+++ b/4. Projects/3. Microservices/Problem/Stage 2/Step 2/Dockerfile-auth
@@ -1,4 +1,4 @@
-FROM rust:1.68.2-alpine3.17 AS chef
+FROM rust:1.77.0-alpine3.19 AS chef
 USER root
 # remove the line below when switching to >=rust:1.70.0. sparse mode is planned to be the default in Rust 1.70.0
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse

--- a/4. Projects/3. Microservices/Problem/Stage 2/Step 2/Dockerfile-health
+++ b/4. Projects/3. Microservices/Problem/Stage 2/Step 2/Dockerfile-health
@@ -1,4 +1,4 @@
-FROM rust:1.68.2-alpine3.17 AS chef
+FROM rust:1.77.0-alpine3.19 AS chef
 USER root
 # remove the line below when switching to >=rust:1.70.0. sparse mode is planned to be the default in Rust 1.70.0
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse


### PR DESCRIPTION
Not sure if you want to leave these in for the need for boot camp people to debug any issues along the way 

fixes prod.yaml spacing error

Failing: `docker compose up`  because rust version is out of date for dependency requirements