### PR TITLE
Adds content type headers for curl tests in docs

### DIFF
--- a/4. Projects/2. API-axum/Problem/Stage 1/README.md
+++ b/4. Projects/2. API-axum/Problem/Stage 1/README.md
@@ -230,6 +230,7 @@ Create question
 curl --request POST \
   --url http://localhost:8000/question \
   --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
   --data '{
 	"title": "Title",
 	"description": "Description"
@@ -250,6 +251,7 @@ Delete question
 curl --request DELETE \
   --url http://localhost:8000/question \
   --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
   --data '{
 	"question_uuid": "[UUID of a created question]"
 }'
@@ -261,6 +263,7 @@ Create answer
 curl --request POST \
   --url http://localhost:8000/answer \
   --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
   --data '{
 	"question_uuid": "[UUID of a created question]",
 	"content": "Content"
@@ -284,6 +287,7 @@ Delete answer
 curl --request DELETE \
   --url http://localhost:8000/answer \
   --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
   --data '{
 	"answer_uuid": "[UUID of a created answer]"
 }'


### PR DESCRIPTION
While doing the exercise i realized that the curl tests for the first stage did not work on my machine. I got an 415 HTTP error specifying that the provided media type is not correct. Since  we're sending json data we should also specify the content type of the sent data. For details of the output se below:

```
julie@Gsiminurok MINGW64 /g/dev/learning-rust/api-axum (main)
$ curl --request POST   --url http://localhost:8000/question   --header 'Accept: application/json'   --data '{
        "title": "Title",
        "description": "Description"
}' --verbose
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:8000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8000...
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000
* using HTTP/1.x
> POST /question HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.11.0
> Accept: application/json
> Content-Length: 52
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 52 bytes
< HTTP/1.1 415 Unsupported Media Type
< content-type: text/plain; charset=utf-8
< content-length: 54
< date: Tue, 07 Jan 2025 15:51:15 GMT
<
Expected request with `Content-Type: application/json`* Connection #0 to host localhost left intact
```

Updated the test commands to include the media type to fix the issue.
For context i used the curl available in my git-bash on windows.